### PR TITLE
Added support to add spaces if qualified isn't present in import

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -124,6 +124,30 @@ import Name hiding ()
 import {-# SOURCE #-} safe qualified Module as M hiding (a, b, c, d, e, f)
 ```
 
+Add space for qualified with one import having qualified
+
+```haskell qualified given
+import Data.List
+import qualified Data.Text
+```
+
+```haskell qualified expect
+import           Data.List
+import qualified Data.Text
+```
+
+Add space for qualified with no import having qualified
+
+```haskell qualified given
+import Data.List
+import Data.Text
+```
+
+```haskell qualified expect
+import Data.List
+import Data.Text
+```
+
 # Declarations
 
 Type declaration

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -100,7 +100,8 @@ options config =
       lineLen <*>
       indentSpaces <*>
       trailingNewline <*>
-      sortImports
+      sortImports <*>
+      spaceForQualified
       ) <*
       optional (strOption
            (long "style" <> help "Style to print with (historical, now ignored)" <> metavar "STYLE") :: Parser String)
@@ -117,11 +118,13 @@ options config =
         flag Nothing (Just True) (long "sort-imports" <> help "Sort imports in groups" <> showDefault) <|>
          flag Nothing (Just False)  (long "no-sort-imports" <> help "Don't sort imports")
     action = flag Reformat Validate (long "validate" <> help "Check if files are formatted without changing them")
-    makeStyle s mlen tabs trailing imports =
+    spaceForQualified = flag False True (long "space-for-qualified" <> help "Add spaces when import doesn't have qualified in it")
+    makeStyle s mlen tabs trailing imports space =
       s
       { configMaxColumns = mlen
       , configIndentSpaces =  tabs
       , configTrailingNewline =  trailing
       , configSortImports =  fromMaybe (configSortImports s) imports
+      , configSpaceForQualified = space
       }
     files = many (strArgument (metavar "FILENAMES"))

--- a/src/main/Test.hs
+++ b/src/main/Test.hs
@@ -3,32 +3,32 @@
 -- | Test the pretty printer.
 module Main where
 
-import           Data.Algorithm.Diff
-import           Data.Algorithm.DiffOutput
+import Data.Algorithm.Diff
+import Data.Algorithm.DiffOutput
 import qualified Data.ByteString as S
-import           Data.ByteString.Lazy (ByteString)
+import Data.ByteString.Lazy (ByteString)
 import qualified Data.ByteString.Lazy as L
 import qualified Data.ByteString.Lazy.Builder as L
 import qualified Data.ByteString.Lazy.Char8 as L8
 import qualified Data.ByteString.Lazy.UTF8 as LUTF8
 import qualified Data.ByteString.UTF8 as UTF8
-import           Data.Function
-import           Data.Monoid
+import Data.Function
+import Data.Monoid
 import qualified HIndent
-import           HIndent.CodeBlock
-import           HIndent.Types
-import           Markdone
-import           Test.Hspec
+import HIndent.CodeBlock
+import HIndent.Types
+import Markdone
+import Test.Hspec
 
 -- | Main benchmarks.
 main :: IO ()
 main = do
-    bytes <- S.readFile "TESTS.md"
-    forest <- parse (tokenize bytes)
-    hspec $ do
-      codeBlocksSpec
-      markdoneSpec
-      toSpec forest
+  bytes <- S.readFile "TESTS.md"
+  forest <- parse (tokenize bytes)
+  hspec $ do
+    codeBlocksSpec
+    markdoneSpec
+    toSpec forest
 
 reformat :: Config -> S.ByteString -> ByteString
 reformat cfg code =
@@ -66,6 +66,16 @@ toSpec = go
         "haskell pending" -> do
           it (UTF8.toString desc) pending
           go next
+        "haskell qualified given" -> do
+          let cfg' = cfg {configSpaceForQualified = True}
+          case skipEmptyLines next of
+            CodeFence "haskell qualified expect" codeExpect:next' -> do
+              it (UTF8.toString desc) $
+                shouldBeReadable (reformat cfg' code) (L.fromStrict codeExpect)
+              go next'
+            _ ->
+              error
+                "'haskell qualified given' block must be followed by a 'haskell qualified expect' block"
         _ -> go next
     go (PlainText {}:next) = go next
     go (CodeFence {}:next) = go next
@@ -78,10 +88,11 @@ shouldBeReadable x y =
   shouldBe (Readable x (Just (diff y x))) (Readable y Nothing)
 
 -- | Prints a string without quoting and escaping.
-data Readable = Readable
-  { readableString :: ByteString
-  , readableDiff :: Maybe String
-  }
+data Readable =
+  Readable
+    { readableString :: ByteString
+    , readableDiff :: Maybe String
+    }
 
 instance Eq Readable where
   (==) = on (==) readableString


### PR DESCRIPTION
This change introduces a new option to format imports so that it adds spaces if qualified isn't present in the statement.
This feature won't add spaces if any of the import statement in a file doesn't have qualified in it despite enabling the flag.

Flag: --space-for-qualified

Sample e.g.
Input
```
import Data.List
import qualified Data.Text
```

Output
```
import           Data.List
import qualified Data.Text
```
By default this feature is turned off for backwards compatibility

Have updated tests for this feature